### PR TITLE
update length expectation

### DIFF
--- a/tests/testthat/test-tmt_gmc.R
+++ b/tests/testthat/test-tmt_gmc.R
@@ -30,8 +30,9 @@ class(plot_class) <- "mst"
 context("test-tmt_gmc")
 # -----------------------------------------------------------------
   test_that("tmt_gmc data structure", {
+    expected_length <- length(ggplot2::ggplot())
     expect_type(p,"list")
-    expect_that(length(p), equals(9))
+    expect_length(p, expected_length)
   })
   test_that("tmt_gmc class", {
        expect_is(


### PR DESCRIPTION
Hello there,

We have been preparing a new release of ggplot2 and during a reverse dependency check, it became apparent that the prospective ggplot2 3.5.0 would break tmt.

The cultprit was a test that expected a ggplot to have length 9, which isn't the case anymorer in the upcoming version. This PR updates that test.

To test the code changes with the release candidate, you can install it with the code below:

```r
remotes::install_github("tidyverse/ggplot2", ref = remotes::github_pull("5592"))
```

The release of ggplot2 3.5.0 is scheduled for the 12th of February. The progress of the release can be tracked in https://github.com/tidyverse/ggplot2/issues/5588. We hope that this PR might help tmt get out a fix if necessary.